### PR TITLE
Removed redundant statement in CONTACT_FORMAT

### DIFF
--- a/src/main/java/duke/enums/ErrorMessages.java
+++ b/src/main/java/duke/enums/ErrorMessages.java
@@ -8,8 +8,7 @@ public enum ErrorMessages {
     KEYWORD_IS_EMPTY("     (>_<) OOPS!!! The keyword cannot be empty."),
     FIXEDDURATION_FORMAT("Format is in: fixedduration <task> /for <duration> <unit>"),
     PRIORITY_FORMAT("     (>_<) OOPS!!! Format is in: setpriority <taskNum> <Priority>"),
-    CONTACT_FORMAT("Format is in: addcontact <name>, <contact>, <email>, <office>\nPut 'Nil' if field is empty\n"
-                    + "Check that email has an '@'"),
+    CONTACT_FORMAT("Format is in: addcontact <name>, <contact>, <email>, <office>\nCheck that email has an '@'"),
     CONTACT_INDEX("     (>_<) OOPS!!! The contact index cannot be empty."),
     NON_INTEGER_ALERT("     Input is not an integer value!"),
     UNKNOWN_COMMAND("     (>_<) OoPS!!! I'm sorry, but I don't know what that means :-("),


### PR DESCRIPTION
Program will automatically fill empty spaces with "Nil", thus users don't need to do so